### PR TITLE
Fixed bug in trophic_level() and aspect_ratio()

### DIFF
--- a/R/aspect_ratio.R
+++ b/R/aspect_ratio.R
@@ -25,7 +25,7 @@
 aspect_ratio <- function(sp) {
     check_name_fishbase(sp)
     ma <- morphometrics(sp)
-    if (length(ma) == 0) {
+    if (is.na(mean(ma$AspectRatio, na.rm = TRUE))) {
         genus <- strsplit(sp, " ")[[1]][1]
         gn    <- species_list(Genus = genus)
         ma    <- morphometrics(gn)

--- a/R/trophic_level.R
+++ b/R/trophic_level.R
@@ -24,8 +24,8 @@
 trophic_level <- function(sp) {
   check_name_fishbase(sp)
   ecogn <- ecology(sp)
-  if (length(ecogn) == 0) {
-    genus <- species(sp)$Genus
+  if (is.na(mean(ecogn$DietTroph, na.rm = TRUE) & is.na(mean(ecogn$FoodTroph, na.rm = TRUE)))) {
+    genus <- strsplit(sp, " ")[[1]][1]
     gn    <- species_list(Genus = genus)
     ecogn <- ecology(gn)
     level <- "genus"


### PR DESCRIPTION
I found that `aspect_ratio()` and `trophic_level()` do not return genus-level average traits. The value could be `NA`, but only if `level = "genus"`.

``` r
library(fishflux)
library(plyr)
aspect_ratio("Lutjanus griseus")
#>            species aspect_ratio   level
#> 1 Lutjanus griseus      1.77717 species
ldply(lapply(c("Chlorurus spilurus","Zebrasoma scopas"), aspect_ratio))
#>              species aspect_ratio   level
#> 1 Chlorurus spilurus          NaN species
#> 2   Zebrasoma scopas      2.02091 species
```

``` r
library(fishflux)
library(plyr)
trophic_level("Lutjanus griseus")
#>            species trophic_level   level
#> 1 Lutjanus griseus         4.055 species
ldply(lapply(c("Chlorurus spilurus","Zebrasoma scopas"), trophic_level))
#>              species trophic_level   level
#> 1 Chlorurus spilurus           NaN species
#> 2   Zebrasoma scopas             2 species
```
These simple corrections to the conditional statements fix the issue.

``` r
aspect_ratio("Chlorurus spilurus")
#>              species aspect_ratio level
#> 1 Chlorurus spilurus     1.484363 genus
```

``` r
trophic_level("Chlorurus spilurus")
#>              species trophic_level level
#> 1 Chlorurus spilurus          2.09 genus
```
The replacement of `rfishbase::species()` with `strsplit()` in `trophic_level()`, as already used in `aspect_ratio()`, slightly improve performance.